### PR TITLE
Fix minor bulk delete bug

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -50,7 +50,7 @@ public class ParserUtil {
         for (int i = 0; i < indexStrings.length; i++) {
             indexArray[i] = parseIndex(indexStrings[i]);
         }
-        Arrays.sort(indexArray, (x,y) -> y.getZeroBased() - x.getZeroBased());
+        Arrays.sort(indexArray, (x, y) -> y.getZeroBased() - x.getZeroBased());
         return indexArray;
     }
 


### PR DESCRIPTION
* sorted indices in descending order so that the ordering of the indices do not get messed up when one child gets deleted since now its deleted starting from the last child in desc order